### PR TITLE
Improve formatting in readme

### DIFF
--- a/election-results/README.md
+++ b/election-results/README.md
@@ -13,8 +13,8 @@ A result will consist of:
 
 So for example:
 
-Cardiff West, 11014, C, 17803, L, 4923, UKIP, 2069, LD
-Islington South & Finsbury, 22547, L, 9389, C, 4829, LD, 3375, UKIP, 3371, G, 309, Ind
+    Cardiff West, 11014, C, 17803, L, 4923, UKIP, 2069, LD
+    Islington South & Finsbury, 22547, L, 9389, C, 4829, LD, 3375, UKIP, 3371, G, 309, Ind
 
 We want to transform this into a standard result that shows:
 
@@ -24,13 +24,13 @@ We want to transform this into a standard result that shows:
 
 ### Codes
 
-C - Conservative Party
-L - Labour Party
-UKIP - UKIP
-LD - Liberal Democrats
-G - Green Party
-Ind - Independent
-SNP - SNP
+* C - Conservative Party
+* L - Labour Party
+* UKIP - UKIP
+* LD - Liberal Democrats
+* G - Green Party
+* Ind - Independent
+* SNP - SNP
 
 ### Validation
 


### PR DESCRIPTION
The sample input wasn't marked up as a code block, so the two lines ran together confusingly. Also converted the party code list to bullet points for the same reason.