### PR TITLE
chore(docs): Link to Meet requirements page

### DIFF
--- a/CANDIDATE_INFORMATION.md
+++ b/CANDIDATE_INFORMATION.md
@@ -16,6 +16,8 @@ Your interviewer will tell you which exercise you’ll be working on at the star
 ## Remote Interviews
 We conduct remote interviews over [Google Meet](https://meet.google.com/).
 Google Meet is a video conferencing tool that supports screen sharing.
+Google Meet is supported by the major browsers. Full requirements can be found [here](https://support.google.com/meet/answer/7317473?hl=en-GB).
+
 A link will be included on your interview invitation, click it to join.
 Once joined, your interviewer will ask you to share your screen.
 


### PR DESCRIPTION
I had technical difficulties in a recent interview, the cause was using the Brave browser which isn't fully/officially supported by Meet. Link off to the requirements page to provide as much help to a candidate as possible before starting the interview.